### PR TITLE
Prevent duplicate page config

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,7 +8,11 @@ import re
 import faiss
 from sentence_transformers import SentenceTransformer
 
-st.set_page_config(page_title="Document Q&A with RCA", page_icon="📊", layout="wide")
+_PAGE_CONFIG_SENTINEL_ATTR = "_document_qa_page_config_set"
+
+if not getattr(st, _PAGE_CONFIG_SENTINEL_ATTR, False):
+    st.set_page_config(page_title="Document Q&A with RCA", page_icon="📊", layout="wide")
+    setattr(st, _PAGE_CONFIG_SENTINEL_ATTR, True)
 
 # Try to get OpenAI API key
 try:


### PR DESCRIPTION
## Summary
- add a module-level sentinel attribute on the Streamlit module to track whether `set_page_config` has run
- guard the `st.set_page_config` call so it only executes once per process

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68c9c68993288326af23f922a65c6855